### PR TITLE
Allow GitHub to detect Literate Rzk Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.rzk.md linguist-detectable
+overrides/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rzk.md linguist-detectable


### PR DESCRIPTION
It is unfortunately not possible to provide a custom language name (until we have like 100s of repos or so). It is, however, possible to instruct Linguist to detect `*.rzk.md` files as a language other than Markdown that is recognized in [languages.yaml](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml). For more details, see the [overrides docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md) to see what else can be configured.

Now, my questions are:
- What should `*.rzk` files be recognized as?
- Should we ignore the `overrides` folder as "documentation"?